### PR TITLE
Switching from `format("%s-a", var.region)` -> `var.zone` on bastion resource

### DIFF
--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -167,7 +167,7 @@ data "template_file" "startup_script" {
 resource "google_compute_instance" "bastion" {
   name = local.hostname
   machine_type = "g1-small"
-  zone = format("%s-a", var.region)
+  zone = var.zone
   project = var.project
   tags = ["bastion"]
 


### PR DESCRIPTION
Switching from format(%s-a, var.region) -> var.zone on the bastion terraform resource. We already have zone as a variable and the previous doesn't work for the europe-west1 or us-east1 regions (which don't contain a "-a" zone)

Signed-off-by: simonbutt <simonbutt123@gmail.com>