### PR TITLE
Fixed Bastion health check

### DIFF
--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -208,7 +208,7 @@ resource "google_compute_instance" "bastion" {
     command = <<EOF
         READY=""
         for i in $(seq 1 20); do
-          if gcloud compute ssh ${local.hostname} --project ${var.project} --zone ${var.region}-a --command uptime; then
+          if gcloud compute ssh ${local.hostname} --project ${var.project} --zone ${var.zone} --command uptime; then
             READY="yes"
             break;
           fi


### PR DESCRIPTION
Currently, the bastion health check assumes that the resource will only be deployed to zone 'a'.
Related to a similar PR - https://github.com/GoogleCloudPlatform/gke-private-cluster-demo/pull/4